### PR TITLE
Adding ability to deactivate pagination

### DIFF
--- a/src/epics/model.ts
+++ b/src/epics/model.ts
@@ -38,6 +38,13 @@ export class ModelEpic extends Epic {
             tableView: selectTableView(state$.value)
           })
         }
+        const model = this.schema.getModel(payload.modelName as string)
+        const paginate = R.propOr(true, 'paginate', model)
+        if (paginate === false)
+          return {
+            modelName: payload.modelName,
+            variables: R.omit(['page'], variables)
+          }
         return { modelName: payload.modelName, variables }
       }),
       mergeMap((context: any) => {

--- a/src/utils/model.ts
+++ b/src/utils/model.ts
@@ -33,9 +33,11 @@ export const getPaginatedNode = (
   if (node) {
     for (const [fieldName, obj] of Object.entries(node)) {
       const type = schema.getType(modelName, fieldName)
+      const model = schema.getModel(modelName)
+      const paginate = R.pathOr(true, ['fields', fieldName, 'paginate'], model)
 
       // if multi-rel type
-      if (type && type.includes('ToMany') && !R.isEmpty(obj)) {
+      if (type && type.includes('ToMany') && !R.isEmpty(obj) && paginate) {
         const idx = R.pathOr(
           1,
           [modelName, 'fields', fieldName, 'page', 'currentPage'],


### PR DESCRIPTION
This adds the ability to use a  "paginate: false" attribute to the model level of the schema, effectively disabling pagination.
This PR disables the page variable in the query.