### PR TITLE
enhanced makeEpic to allow for larger hierarchy of extended classes

### DIFF
--- a/src/epics/epic.ts
+++ b/src/epics/epic.ts
@@ -12,15 +12,30 @@ export class Epic {
 
   makeEpic() {
     const epics: ROEpic[] = []
-    R.forEach(methodName => {
-      if (!R.includes(methodName, ['constructor', 'makeEpic'])) {
-        const epic: ROEpic = (action$, state$) =>
-          // @ts-ignore
-          this[methodName](action$, state$)
-        Object.defineProperty(epic, 'name', { value: this.constructor.name })
-        epics.push(epic)
-      }
-    }, Object.getOwnPropertyNames(Object.getPrototypeOf(this)))
+    const methods = new Set()
+    let obj: Record<string, any> = this //eslint-disable-line
+    do {
+      obj = Object.getPrototypeOf(obj)
+      Object.getOwnPropertyNames(obj).forEach(name => methods.add(name))
+    } while (Object.getPrototypeOf(obj).constructor.name != 'Epic')
+    R.forEach(
+      methodName => {
+        if (
+          !R.includes(methodName, [
+            'constructor',
+            'makeEpic',
+            '__reactstandin__regenerateByEval'
+          ])
+        ) {
+          const epic: ROEpic = (action$, state$) =>
+            // @ts-ignore
+            this[methodName](action$, state$)
+          Object.defineProperty(epic, 'name', { value: this.constructor.name })
+          epics.push(epic)
+        }
+      },
+      [...methods]
+    )
     return epics
   }
 }


### PR DESCRIPTION
When extending each of the epic classes, to get all property names from the new class and it's super I needed to add a loop to retrieve property names from all levels of the class hierarchy.
If there is a better way to handle this, please let me know.
```
    do {
      obj = Object.getPrototypeOf(obj)
      methods = methods.concat(Object.getOwnPropertyNames(obj));
    } while (Object.getPrototypeOf(obj).constructor.name != 'Epic');
```
Also, the new `methodName != '__reactstandin__regenerateByEval'` code is due to a method by that particular name being picked up that is obviously not an epic method.