### PR TITLE
adding queryAllName field to DATA_OPTIONS_UPDATE reducer

### DIFF
--- a/src/reducers/options.ts
+++ b/src/reducers/options.ts
@@ -44,7 +44,11 @@ export class OptionsReducer extends Reducer {
       ['type', 'target'],
       this.schema.getField(modelName, fieldName)
     ) as any
-    const data = R.path(['data', 'result'], payload) as any
+    const getQueryAllName: (obj: any) => string = R.prop('queryAllName')
+    const queryAllName: string = getQueryAllName(
+      this.schema.getModel(targetModelName)
+    )
+    const data = R.path(['data', queryAllName, 'result'], payload) as any
     const options = data.map((option: any) => ({
       label: this.schema.getDisplayValue({
         modelName: targetModelName,


### PR DESCRIPTION
I needed to add the  queryAllName field to the data path in this reducer, since the query generated by the Epic utilizes queryAllName and the results comes back structured as such.

Need to make sure this doesn't break anything anywhere else. This reducer is not triggered in the autoinvent-example, so I'm not sure if this reducer works anywhere else as is.

`const data = R.path(['data', queryAllName, 'result'], payload)`