### PR TITLE
Pagination display can be modified by passing a config to reducer/epics

### DIFF
--- a/src/epics/epic.ts
+++ b/src/epics/epic.ts
@@ -1,14 +1,16 @@
 import * as R from 'ramda'
 import { SchemaBuilder } from '@autoinvent/conveyor-schema'
-import type { QueryTool, ROEpic } from '../types'
+import type { QueryTool, ROEpic, Config } from '../types'
 
 export class Epic {
   schema: SchemaBuilder
   queryTool: QueryTool
+  config: Config
 
-  constructor(schema: SchemaBuilder, queryTool: QueryTool) {
+  constructor(schema: SchemaBuilder, queryTool: QueryTool, config?: Config) {
     this.schema = schema
     this.queryTool = queryTool
+    this.config = R.isNil(config) ? {} : config
   }
 
   makeEpic() {

--- a/src/epics/epic.ts
+++ b/src/epics/epic.ts
@@ -7,10 +7,10 @@ export class Epic {
   queryTool: QueryTool
   config: Config
 
-  constructor(schema: SchemaBuilder, queryTool: QueryTool, config?: Config) {
+  constructor(schema: SchemaBuilder, queryTool: QueryTool, config: Config) {
     this.schema = schema
     this.queryTool = queryTool
-    this.config = R.isNil(config) ? {} : config
+    this.config = config
   }
 
   makeEpic() {

--- a/src/epics/index.ts
+++ b/src/epics/index.ts
@@ -35,11 +35,16 @@ const conveyorEpics = [
 export class ConveyorEpic {
   schema: SchemaBuilder
   queryTool: QueryTool
-  config: Config | undefined
+  config: Config
 
-  constructor(schema: SchemaBuilder, queryTool: QueryTool, config?: Config) {
-    this.schema = schema
-    ;(this.queryTool = queryTool), (this.config = config)
+  constructor(
+    schema: SchemaBuilder,
+    queryTool: QueryTool,
+    config: Config = {}
+  ) {
+    ;(this.schema = schema),
+      (this.queryTool = queryTool),
+      (this.config = config)
   }
 
   makeEpic(store: any) {

--- a/src/epics/index.ts
+++ b/src/epics/index.ts
@@ -16,6 +16,7 @@ import type { QueryTool } from '../types'
 import * as Actions from '../actions'
 import * as Logger from '../utils/Logger'
 import * as R from 'ramda'
+import { Config } from '../types'
 
 const conveyorEpics = [
   AlertEpic,
@@ -34,10 +35,11 @@ const conveyorEpics = [
 export class ConveyorEpic {
   schema: SchemaBuilder
   queryTool: QueryTool
+  config: Config | undefined
 
-  constructor(schema: SchemaBuilder, queryTool: QueryTool) {
+  constructor(schema: SchemaBuilder, queryTool: QueryTool, config?: Config) {
     this.schema = schema
-    this.queryTool = queryTool
+    ;(this.queryTool = queryTool), (this.config = config)
   }
 
   makeEpic(store: any) {
@@ -45,7 +47,8 @@ export class ConveyorEpic {
       store,
       ...R.flatten(
         R.map(
-          (Epic) => new Epic(this.schema, this.queryTool).makeEpic(),
+          (Epic) =>
+            new Epic(this.schema, this.queryTool, this.config).makeEpic(),
           conveyorEpics
         )
       )

--- a/src/epics/model.ts
+++ b/src/epics/model.ts
@@ -16,9 +16,15 @@ import { concat } from 'rxjs'
 import * as Logger from '../utils/Logger'
 import { Epic } from './epic'
 import { EpicPayload } from '../types'
+import { DEFAULT_PAGINATION_AMT } from '../utils/tableView'
 
 export class ModelEpic extends Epic {
   [FETCH_MODEL_INDEX](action$: any, state$: any) {
+    const defaultPerPage = R.pathOr(
+      DEFAULT_PAGINATION_AMT,
+      ['tableView', 'defaultPerPage'],
+      this.config
+    )
     return action$.pipe(
       ofType(FETCH_MODEL_INDEX, CHANGE_PAGE),
       map(R.prop('payload')),
@@ -36,7 +42,8 @@ export class ModelEpic extends Epic {
           }),
           page: getPage({
             modelName: payload.modelName as string,
-            tableView: selectTableView(state$.value)
+            tableView: selectTableView(state$.value),
+            defaultPerPage: defaultPerPage
           })
         }
         const model = this.schema.getModel(payload.modelName as string)

--- a/src/epics/model.ts
+++ b/src/epics/model.ts
@@ -20,11 +20,8 @@ import { DEFAULT_PAGINATION_AMT } from '../utils/tableView'
 
 export class ModelEpic extends Epic {
   [FETCH_MODEL_INDEX](action$: any, state$: any) {
-    const defaultPerPage = R.pathOr(
-      DEFAULT_PAGINATION_AMT,
-      ['tableView', 'defaultPerPage'],
-      this.config
-    )
+    const defaultPerPage =
+      this.config.tableView?.defaultPerPage ?? DEFAULT_PAGINATION_AMT
     return action$.pipe(
       ofType(FETCH_MODEL_INDEX, CHANGE_PAGE),
       map(R.prop('payload')),

--- a/src/reducers/alerts.ts
+++ b/src/reducers/alerts.ts
@@ -8,10 +8,11 @@ import {
 import { SchemaBuilder } from '@autoinvent/conveyor-schema'
 import { Reducer } from './reducer'
 import * as R from 'ramda'
+import { Config } from '../types'
 
 export class AlertsReducer extends Reducer {
-  constructor(schema: SchemaBuilder) {
-    super(schema, initState)
+  constructor(schema: SchemaBuilder, config: Config) {
+    super(schema, initState, config)
   }
 
   [ADD_DANGER_ALERT](state: any, action: any) {

--- a/src/reducers/create.ts
+++ b/src/reducers/create.ts
@@ -22,10 +22,11 @@ import {
 } from '../actionConsts'
 import { Reducer } from './reducer'
 import { SchemaBuilder } from '@autoinvent/conveyor-schema'
+import { Config } from '../types'
 
 export class CreateReducer extends Reducer {
-  constructor(schema: SchemaBuilder) {
-    super(schema, initState)
+  constructor(schema: SchemaBuilder, config: Config) {
+    super(schema, initState, config)
   }
 
   [CREATE_INPUT_CHANGE](state: any, action: any) {

--- a/src/reducers/edit.ts
+++ b/src/reducers/edit.ts
@@ -14,10 +14,11 @@ import {
 import { LOCATION_CHANGE } from 'connected-react-router'
 import { SchemaBuilder } from '@autoinvent/conveyor-schema'
 import { Reducer } from './reducer'
+import { Config } from '../types'
 
 export class EditReducer extends Reducer {
-  constructor(schema: SchemaBuilder) {
-    super(schema, initState)
+  constructor(schema: SchemaBuilder, config: Config) {
+    super(schema, initState, config)
   }
 
   [LOCATION_CHANGE]() {

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -27,7 +27,7 @@ const conveyorReducerMap = {
 }
 
 export class ConveyorReducer {
-  constructor(schema: SchemaBuilder, overrides?: any, config?: Config) {
+  constructor(schema: SchemaBuilder, overrides?: any, config: Config = {}) {
     const identity: (value: any) => any = R.identity
     const mergedReducerMap = R.filter(
       identity,

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -11,6 +11,7 @@ import { TableViewReducer } from './tableView'
 import { SearchReducer } from './search'
 import { SchemaBuilder } from '@autoinvent/conveyor-schema'
 import { UserPreferencesReducer } from './userPreferences'
+import { Config } from '../types'
 
 const conveyorReducerMap = {
   alerts: AlertsReducer,
@@ -26,7 +27,7 @@ const conveyorReducerMap = {
 }
 
 export class ConveyorReducer {
-  constructor(schema: SchemaBuilder, overrides?: any) {
+  constructor(schema: SchemaBuilder, overrides?: any, config?: Config) {
     const identity: (value: any) => any = R.identity
     const mergedReducerMap = R.filter(
       identity,
@@ -34,7 +35,7 @@ export class ConveyorReducer {
     )
     R.forEachObjIndexed((Reducer, key) => {
       // @ts-ignore
-      this[key] = new Reducer(schema)
+      this[key] = new Reducer(schema, config)
     }, mergedReducerMap)
   }
 

--- a/src/reducers/modal.ts
+++ b/src/reducers/modal.ts
@@ -3,10 +3,11 @@ import { UPDATE_DELETE_DETAIL, CANCEL_DELETE_DETAIL } from '../actionConsts'
 import { initState, groupModels } from '../utils/modal'
 import { SchemaBuilder } from '@autoinvent/conveyor-schema'
 import { Reducer } from './reducer'
+import { Config } from '../types'
 
 export class ModalReducer extends Reducer {
-  constructor(schema: SchemaBuilder) {
-    super(schema, initState)
+  constructor(schema: SchemaBuilder, config: Config) {
+    super(schema, initState, config)
   }
 
   [UPDATE_DELETE_DETAIL](state: any, action: any) {

--- a/src/reducers/model.ts
+++ b/src/reducers/model.ts
@@ -9,10 +9,11 @@ import {
 import { initState, updateIndex, getDefaultModelStore } from '../utils/model'
 import { SchemaBuilder } from '@autoinvent/conveyor-schema'
 import { Reducer } from './reducer'
+import { Config } from '../types'
 
 export class ModelReducer extends Reducer {
-  constructor(schema: SchemaBuilder) {
-    super(schema, initState)
+  constructor(schema: SchemaBuilder, config: Config) {
+    super(schema, initState, config)
   }
 
   [MODEL_NOT_FOUND](state: any, action: any) {

--- a/src/reducers/options.ts
+++ b/src/reducers/options.ts
@@ -7,10 +7,11 @@ import {
 import { initState } from '../utils/options'
 import { Reducer } from './reducer'
 import { SchemaBuilder } from '@autoinvent/conveyor-schema'
+import { Config } from '../types'
 
 export class OptionsReducer extends Reducer {
-  constructor(schema: SchemaBuilder) {
-    super(schema, initState)
+  constructor(schema: SchemaBuilder, config: Config) {
+    super(schema, initState, config)
   }
 
   [MENU_OPEN](state: any, action: any) {

--- a/src/reducers/reducer.ts
+++ b/src/reducers/reducer.ts
@@ -1,13 +1,16 @@
 import * as R from 'ramda'
 import { SchemaBuilder } from '@autoinvent/conveyor-schema'
+import { Config } from '../types'
 
 export class Reducer {
   schema: SchemaBuilder
   initState: any
+  config: Config
 
-  constructor(schema: SchemaBuilder, initState: any) {
+  constructor(schema: SchemaBuilder, initState: any, config?: Config) {
     this.schema = schema
     this.initState = initState
+    this.config = R.isNil(config) ? {} : config
   }
 
   reduce(state: any, action: any) {

--- a/src/reducers/reducer.ts
+++ b/src/reducers/reducer.ts
@@ -7,10 +7,10 @@ export class Reducer {
   initState: any
   config: Config
 
-  constructor(schema: SchemaBuilder, initState: any, config?: Config) {
+  constructor(schema: SchemaBuilder, initState: any, config: Config) {
     this.schema = schema
     this.initState = initState
-    this.config = R.isNil(config) ? {} : config
+    this.config = config
   }
 
   reduce(state: any, action: any) {

--- a/src/reducers/search.ts
+++ b/src/reducers/search.ts
@@ -9,10 +9,11 @@ import {
 import { initState } from '../utils/search'
 import { Reducer } from './reducer'
 import { SchemaBuilder } from '@autoinvent/conveyor-schema'
+import { Config } from '../types'
 
 export class SearchReducer extends Reducer {
-  constructor(schema: SchemaBuilder) {
-    super(schema, initState)
+  constructor(schema: SchemaBuilder, config: Config) {
+    super(schema, initState, config)
   }
 
   [UPDATE_SEARCH_ENTRIES](state: any, action: any) {

--- a/src/reducers/tableView.ts
+++ b/src/reducers/tableView.ts
@@ -23,10 +23,18 @@ import {
 } from '../utils/tableView'
 import { SchemaBuilder } from '@autoinvent/conveyor-schema'
 import { Reducer } from './reducer'
+import { Config } from '../types'
 
 export class TableViewReducer extends Reducer {
-  constructor(schema: SchemaBuilder) {
-    super(schema, initState)
+  defaultPerPage: number
+
+  constructor(schema: SchemaBuilder, config?: Config) {
+    super(schema, initState, config)
+    this.defaultPerPage = R.pathOr(
+      DEFAULT_PAGINATION_AMT,
+      ['tableView', 'defaultPerPage'],
+      this.config
+    )
   }
 
   [INDEX_ADD_FILTER](state: any, action: any) {
@@ -228,13 +236,13 @@ export class TableViewReducer extends Reducer {
     let lastIndex = null
     if (count) {
       // @ts-ignore
-      lastIndex = Math.ceil(count / DEFAULT_PAGINATION_AMT)
+      lastIndex = Math.ceil(count / this.defaultPerPage)
     }
 
     return R.pipe(
       R.assocPath([modelName, 'page', 'lastIndex'], lastIndex),
       R.assocPath([modelName, 'page', 'total'], count),
-      R.assocPath([modelName, 'page', 'amtPerPage'], DEFAULT_PAGINATION_AMT)
+      R.assocPath([modelName, 'page', 'amtPerPage'], this.defaultPerPage)
     )(state)
   }
 
@@ -252,9 +260,7 @@ export class TableViewReducer extends Reducer {
         // if multi-rel type
         if (type && type.includes('ToMany') && !R.isEmpty(obj)) {
           const totalDataLength = obj.length
-          const lastIndexRel = Math.ceil(
-            totalDataLength / DEFAULT_PAGINATION_AMT
-          )
+          const lastIndexRel = Math.ceil(totalDataLength / this.defaultPerPage)
           if (lastIndexRel > 0) {
             state = R.pipe(
               R.assocPath(
@@ -267,7 +273,7 @@ export class TableViewReducer extends Reducer {
               ),
               R.assocPath(
                 [modelName, 'fields', fieldName, 'page', 'amtPerPage'],
-                DEFAULT_PAGINATION_AMT
+                this.defaultPerPage
               )
             )(state)
           }

--- a/src/reducers/tableView.ts
+++ b/src/reducers/tableView.ts
@@ -28,7 +28,7 @@ import { Config } from '../types'
 export class TableViewReducer extends Reducer {
   defaultPerPage: number
 
-  constructor(schema: SchemaBuilder, config?: Config) {
+  constructor(schema: SchemaBuilder, config: Config) {
     super(schema, initState, config)
     this.defaultPerPage = R.pathOr(
       DEFAULT_PAGINATION_AMT,

--- a/src/reducers/tooltip.ts
+++ b/src/reducers/tooltip.ts
@@ -3,10 +3,11 @@ import { UPDATE_MODEL_TOOLTIP } from '../actionConsts'
 import { initState } from '../utils/tooltip'
 import { Reducer } from './reducer'
 import { SchemaBuilder } from '@autoinvent/conveyor-schema'
+import { Config } from '../types'
 
 export class TooltipReducer extends Reducer {
-  constructor(schema: SchemaBuilder) {
-    super(schema, initState)
+  constructor(schema: SchemaBuilder, config: Config) {
+    super(schema, initState, config)
   }
 
   [UPDATE_MODEL_TOOLTIP](state: any, action: any) {

--- a/src/reducers/userPreferences.ts
+++ b/src/reducers/userPreferences.ts
@@ -3,10 +3,11 @@ import { TOGGLE_DARK_MODE } from '../actionConsts'
 import { SchemaBuilder } from '@autoinvent/conveyor-schema'
 import { Reducer } from './reducer'
 import * as R from 'ramda'
+import { Config } from '../types'
 
 export class UserPreferencesReducer extends Reducer {
-  constructor(schema: SchemaBuilder) {
-    super(schema, initState)
+  constructor(schema: SchemaBuilder, config: Config) {
+    super(schema, initState, config)
   }
   [TOGGLE_DARK_MODE](state: any) {
     // @ts-ignore

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,3 +98,7 @@ export const isRequestError = (
 export interface ErrorItem {
   message: string
 }
+
+export interface Config {
+  [key: string]: any
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,5 +100,7 @@ export interface ErrorItem {
 }
 
 export interface Config {
-  [key: string]: any
+  tableView?: {
+    defaultPerPage?: number
+  }
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -4,7 +4,6 @@ import * as Actions from '../actions'
 import * as consts from '../actionConsts'
 import * as Logger from './Logger'
 import { SchemaBuilder } from '@autoinvent/conveyor-schema'
-import { DEFAULT_PAGINATION_AMT } from './tableView'
 
 export const storeValueToArrayBuffer = (value: number[]) => {
   const arrayBuffer = new ArrayBuffer(value.length)
@@ -97,13 +96,15 @@ export const getSort = ({
 
 export const getPage = ({
   modelName,
-  tableView
+  tableView,
+  defaultPerPage
 }: {
   modelName: string
   tableView: any
+  defaultPerPage: number
 }) => {
   const currentPage = R.pathOr(1, [modelName, 'page', 'currentPage'], tableView)
-  return { current: currentPage, per_page: DEFAULT_PAGINATION_AMT }
+  return { current: currentPage, per_page: defaultPerPage }
 }
 
 export const editFieldToQueryInput = ({

--- a/src/utils/tableView.ts
+++ b/src/utils/tableView.ts
@@ -1,6 +1,5 @@
 import * as R from 'ramda'
 
-// todo: user should be able to specify this number when instantiating conveyor-redux reducer classes
 export const DEFAULT_PAGINATION_AMT = 20
 
 export const initState = {}


### PR DESCRIPTION
fixes #17

- Added optional config parameter to base Reducer and Epic class
- Pagination amount will default to DEFAULT_PAGINATION_AMT if no config is provided. Pagination amount mostly stored in 'defaultPerPage' variable inside of Conveyor-Redux

## Usage: ##
- Declare a config in your main project like so
```
const config = {
  tableView: {
    defaultPerPage: 5
  }
}
```
- Pass it in when declaring ConveyorReducer and ConveyorEpic
```
conveyor: new ConveyorReducer(schema, null, config)  // Reducer
...
const conveyorEpic = new ConveyorEpic(schema, magqlQuery, config)  // Epic
```