### PR TITLE
do-not-include-object-data-in-delete-detail-without-valid-typename

### DIFF
--- a/src/utils/modal.ts
+++ b/src/utils/modal.ts
@@ -7,6 +7,10 @@ export const groupModels = (collection: any, property: any) => {
   const result = []
   for (let i = 0; i < collection.length; i++) {
     const val = collection[i][property]
+    if (typeof val === 'undefined') {
+      //Test for objects without type, affected models we don't care about reporting.
+      continue
+    }
     const index = values.indexOf(val)
     if (index > -1) {
       result[index].push(collection[i])


### PR DESCRIPTION
if an object would be deleted by cascade effects, but we do not want to show it in the delete modal, showDeleteModal=false. Then graphql will return an empty {} value in the response to the front end. This change keeps groupModels from including that empty value which can potential crash the page if it is passed to conveyor components.