### PR TITLE
Fixes #75: Do not reset the searchPageFilters when queryText is cleared

### DIFF
--- a/src/reducers/search.ts
+++ b/src/reducers/search.ts
@@ -124,8 +124,11 @@ export class SearchReducer extends Reducer {
     if (newQueryText) {
       return R.assoc('queryText', newQueryText, state)
     }
-    // Do not reset the searchPageEntries
-    return R.assoc('searchPageEntries', state.searchPageEntries, initState)
+    // Do not reset the searchPageEntries nor searchPageFilters
+    return R.pipe(
+      R.assoc('searchPageEntries', state.searchPageEntries),
+      R.assoc('searchPageFilters', state.searchPageFilters)
+    )(initState)
   }
 
   /**


### PR DESCRIPTION
Had to update the SEARCH_QUERY_TEXT_CHANGED reducer so that the searchPageFilters are also not cleared when queryText is cleared

closes #75 