### PR TITLE
make searchPageEntries null for initial so we can tell if the search …

### DIFF
--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -3,7 +3,7 @@ import * as R from 'ramda'
 export const initState = {
   queryText: '',
   quickSearchEntries: [],
-  searchPageEntries: [],
+  searchPageEntries: null,
   searchPageFilters: [],
   dropdown: false
 }


### PR DESCRIPTION
…has been run or not.

Needed to fix a bug with search.
see:  https://github.com/autoinvent/conveyor/pull/155