### PR TITLE
Adding yarn cache to github actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,6 +12,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+            path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+            restore-keys: |
+              ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: yarn
       - name: Build
@@ -22,6 +32,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+            path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+            key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+            restore-keys: |
+              ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: yarn
       - name: Lint


### PR DESCRIPTION
Github actions will now check cache based on hash of yarn.lock.
Will not do anything on first request, but on future requests will use yarn cache if able.
Still need to run yarn for node_modules dependencies.